### PR TITLE
Respect "docs_dir" key for both master and merged sites

### DIFF
--- a/mkdocsmerge/merge.py
+++ b/mkdocsmerge/merge.py
@@ -15,9 +15,6 @@ def run_merge(master_site, sites, unify_sites, print_func):
                    'site.\nUse "mkdocs-merge run -h" for more information.')
         return
 
-    # NOTE: need to do this otherwise subsequent distutil.copy_tree will fail if
-    # mkdocs-merge is used as a module (https://stackoverflow.com/a/28055993/920464)
-    distutils.dir_util._path_created = {}
 
     # Get all site's pages and copy their files
     return merge_sites(sites, master_site, unify_sites, print_func)
@@ -41,6 +38,9 @@ def merge_sites(sites, master_site, unify_sites, print_func):
         master_data = myaml.load(master_file)
 
     master_docs_dir = master_data.get('docs_dir', 'docs')
+    # NOTE: need to do this otherwise subsequent distutil.copy_tree will fail if
+    # mkdocs-merge is used as a module (https://stackoverflow.com/a/28055993/920464)
+    distutils.dir_util._path_created = {}
 
     new_pages = []
     for site in sites:

--- a/mkdocsmerge/merge.py
+++ b/mkdocsmerge/merge.py
@@ -40,7 +40,7 @@ def merge_sites(sites, master_site, unify_sites, print_func):
     with open(master_yaml) as master_file:
         master_data = myaml.load(master_file)
 
-    master_docs_dir = site_docs_dir = master_data.get('docs_dir', 'docs')
+    master_docs_dir = master_data.get('docs_dir', 'docs')
 
     new_pages = []
     for site in sites:

--- a/mkdocsmerge/tests/run_merge_test.py
+++ b/mkdocsmerge/tests/run_merge_test.py
@@ -1,10 +1,11 @@
-import tempfile
-import unittest
 import os
 import shutil
-from .utils import generate_website, make_simple_yaml
+import tempfile
+import unittest
 
 import mkdocsmerge.merge
+
+from .utils import generate_website, make_simple_yaml
 
 
 class TestRunMerge(unittest.TestCase):

--- a/mkdocsmerge/tests/run_merge_test.py
+++ b/mkdocsmerge/tests/run_merge_test.py
@@ -30,10 +30,13 @@ class TestRunMerge(unittest.TestCase):
             True, lambda x: None)
 
         for site_name in site_names[1:]:
-            self.assertTrue(os.path.exists(os.path.join(site_name,
-                docs_dir_map.get(site_name, 'docs'), 'index.md')))
-            self.assertTrue(os.path.exists(os.path.join(site_names[0],
-                docs_dir_map.get(site_names[0], 'docs'), '%s_website' % site_name)))
+            index_path = os.path.join(site_name,
+                docs_dir_map.get(site_name, 'docs'), 'index.md')
+            self.assertTrue(os.path.exists(index_path))
+
+            docs_dir_path = os.path.join(site_names[0],
+                docs_dir_map.get(site_names[0], 'docs'), '%s_website' % site_name.lower())
+            self.assertTrue(os.path.exists(docs_dir_path))
 
         self.assertEqual(merged_pages,
         {

--- a/mkdocsmerge/tests/run_merge_test.py
+++ b/mkdocsmerge/tests/run_merge_test.py
@@ -26,27 +26,27 @@ class TestRunMerge(unittest.TestCase):
             yml = make_simple_yaml(site_name, docs_dir)
             generate_website(self.tmpdir, site_name, yml)
 
-        merged_pages = mkdocsmerge.merge.run_merge(site_names[0], site_names[1:],
-            True, lambda x: None)
+        merged_pages = mkdocsmerge.merge.run_merge(
+            site_names[0], site_names[1:], True, lambda x: None)
 
         for site_name in site_names[1:]:
-            index_path = os.path.join(site_name,
-                docs_dir_map.get(site_name, 'docs'), 'index.md')
+            index_path = os.path.join(
+                site_name, docs_dir_map.get(site_name, 'docs'), 'index.md')
             self.assertTrue(os.path.exists(index_path))
 
-            docs_dir_path = os.path.join(site_names[0],
-                docs_dir_map.get(site_names[0], 'docs'), '%s_website' % site_name.lower())
+            docs_dir_path = os.path.join(
+                site_names[0], docs_dir_map.get(site_names[0], 'docs'),
+                '%s_website' % site_name.lower())
             self.assertTrue(os.path.exists(docs_dir_path))
 
-        self.assertEqual(merged_pages,
-        {
+        self.assertEqual(merged_pages, {
             'site_name': '__master__ Website',
             'pages': [
                 {'Home': "index.md"},
                 {'Foo Website': [
                     {'Home': 'foo_website/index.md'}
                 ]},
-                {'Bar Website' : [
+                {'Bar Website': [
                     {'Home': 'bar_website/index.md'}
                 ]},
                 {'Test Website': [

--- a/mkdocsmerge/tests/run_merge_test.py
+++ b/mkdocsmerge/tests/run_merge_test.py
@@ -5,7 +5,6 @@ import shutil
 from .utils import generate_website, make_simple_yaml
 
 import mkdocsmerge.merge
-from ruamel.yaml import YAML
 
 
 class TestRunMerge(unittest.TestCase):

--- a/mkdocsmerge/tests/run_merge_test.py
+++ b/mkdocsmerge/tests/run_merge_test.py
@@ -1,0 +1,58 @@
+import tempfile
+import unittest
+import os
+import shutil
+from .utils import generate_website, make_simple_yaml
+
+import mkdocsmerge.merge
+from ruamel.yaml import YAML
+
+
+class TestRunMerge(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        os.chdir(self.tmpdir)
+
+    def test_run_merge(self):
+
+        docs_dir_map = {
+            '__master__': 'master_docs',
+            'Test': 'test_docs'
+        }
+
+        site_names = ['__master__', 'Foo', 'Bar', 'Test']
+        for site_name in site_names:
+            docs_dir = docs_dir_map.get(site_name, None)
+            yml = make_simple_yaml(site_name, docs_dir)
+            generate_website(self.tmpdir, site_name, yml)
+
+        merged_pages = mkdocsmerge.merge.run_merge(site_names[0], site_names[1:],
+            True, lambda x: None)
+
+        for site_name in site_names[1:]:
+            self.assertTrue(os.path.exists(os.path.join(site_name,
+                docs_dir_map.get(site_name, 'docs'), 'index.md')))
+            self.assertTrue(os.path.exists(os.path.join(site_names[0],
+                docs_dir_map.get(site_names[0], 'docs'), '%s_website' % site_name)))
+
+        self.assertEqual(merged_pages,
+        {
+            'site_name': '__master__ Website',
+            'pages': [
+                {'Home': "index.md"},
+                {'Foo Website': [
+                    {'Home': 'foo_website/index.md'}
+                ]},
+                {'Bar Website' : [
+                    {'Home': 'bar_website/index.md'}
+                ]},
+                {'Test Website': [
+                    {'Home': 'test_website/index.md'}
+                ]}
+            ],
+            'docs_dir': 'master_docs'
+        })
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)

--- a/mkdocsmerge/tests/utils.py
+++ b/mkdocsmerge/tests/utils.py
@@ -42,7 +42,8 @@ def generate_dummy_pages(docs_dir, key, node):
             generate_dummy_pages(docs_dir, k, v)
     else:
         path = os.path.join(docs_dir, str.replace(node, '\\', '/'))
-        os.makedirs(os.path.dirname(path), exist_ok=True)
+        if not os.path.exists(os.path.dirname(path)):
+            os.makedirs(os.path.dirname(path))
         with open(path, 'w') as mdf:
             mdf.write("""
 * %s Title

--- a/mkdocsmerge/tests/utils.py
+++ b/mkdocsmerge/tests/utils.py
@@ -1,0 +1,50 @@
+import os
+from ruamel.yaml import YAML
+
+
+def generate_website(directory, name, yml=None):
+    root = os.path.join(directory, name)
+    os.mkdir(root)
+
+    if yml is None:
+        yml = make_simple_yaml(name)
+
+    yaml = YAML()
+    with open(os.path.join(root, 'mkdocs.yml'), 'w') as f:
+        yaml.dump(yml, f)
+
+    docs_folder = yml.get('docs_dir', 'docs')
+
+    docs_dir = os.path.join(root, docs_folder)
+    os.mkdir(docs_dir)
+    generate_dummy_pages(docs_dir, 'pages', yml['pages'])
+
+
+def make_simple_yaml(name, docs_dir=None):
+    yml = {
+        'site_name': '%s Website' % name,
+        'pages': [
+            {'Home': "index.md"},
+        ]
+    }
+
+    if docs_dir:
+        yml['docs_dir'] = docs_dir
+    return yml
+
+
+def generate_dummy_pages(docs_dir, key, node):
+    if isinstance(node, list):
+        for item in node:
+            generate_dummy_pages(docs_dir, key, item)
+    elif isinstance(node, dict):
+        for k, v in node.items():
+            generate_dummy_pages(docs_dir, k, v)
+    else:
+        path = os.path.join(docs_dir, str.replace(node, '\\', '/'))
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, 'w') as mdf:
+            mdf.write("""
+* %s Title
+Contents
+""" % key)


### PR DESCRIPTION
Initially, if a site had a different `docs_dir`, _mkdocs-merge_ would have skipped the site with:

```
Could not find the site "docs" folder. This site be skipped: ...
```

This PR will fix that and respect the `docs_dir` key from mkdocs.yml for both master and merged sites.