### PR TITLE
Drop support for python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ matrix:
     include:
         - python: 2.7
           env: TOXENV=py27
-        - python: 3.3
-          env: TOXENV=py33
         - python: 3.4
           env: TOXENV=py34
         - python: 3.5

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Supports unification of sites with the same `site_name` into a single sub-site.
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/10abc652aca046079f4ab069af689163)](https://www.codacy.com/app/oscarv19/mkdocs-merge?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=ovasquez/mkdocs-merge&amp;utm_campaign=Badge_Grade)
 [![Codacy Badge](https://api.codacy.com/project/badge/Coverage/10abc652aca046079f4ab069af689163)](https://www.codacy.com/app/oscarv19/mkdocs-merge?utm_source=github.com&utm_medium=referral&utm_content=ovasquez/mkdocs-merge&utm_campaign=Badge_Coverage)
 
-MkDocs-Merge supports Python versions 2.7, 3.3, 3.4, 3.5, 3.6 and pypy.
+MkDocs-Merge supports Python versions 2.7, 3.4, 3.5, 3.6 and pypy.
 
 ## Install
 

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',


### PR DESCRIPTION
According to https://github.com/pypa/pip/issues/3796 pip has dropped support for python 3.3. We should do the same if we want to have our checks green (merge this first).