### PR TITLE
Moving from dir_util to shutil, release 0.10.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Oscar Vasquez
+Copyright (c) 2025 Oscar Vasquez
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -74,6 +74,18 @@ nav:
 Clone the repository and specify the `dev` dependencies on the install command.
 Project has been updated to use `pyproject.toml` so the version has to be manually synchronized in both `__init__.py` and `pyproject.toml`.
 
+#### Setup Virtual Environment
+
+Before installing the package, create and activate a virtual environment in the root directory of the repo:
+
+```bash
+cd <root of the cloned repo>
+python -m venv .venv
+source .venv/bin/activate
+```
+
+#### Install the package for development mode
+
 ```bash
 # Using quotes for zsh compatibility
 $ pip install -e '.[dev]'

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.10.0 - May 17, 2025
+- Replaced `dir_util.copy_tree` with `shutil.copytree` to use a built-in and maintained API in the directory merge functionality.
+- Added a test to verify the scenario of deleting paths and merging them again when using mkdocs-merge as a module.
+
 ## 0.9.0 - July 30, 2024
 - Fixed bug of `dir_util.copy_tree` caused by setuptools moving to 70.2.0 (fixes [#20](https://github.com/ovasquez/mkdocs-merge/issues/20)).
 - Updated dependency on deprecated distutils package to use setuptools version.

--- a/docs/index.md
+++ b/docs/index.md
@@ -71,6 +71,18 @@ nav:
 Clone the repository and specify the `dev` dependencies on the install command.
 Project has been updated to use `pyproject.toml` so the version has to be manually synchronized.
 
+#### Setup Virtual Environment
+
+Before installing the package, create and activate a virtual environment in the root directory of the repo:
+
+```bash
+cd <root of the cloned repo>
+python -m venv .venv
+source .venv/bin/activate
+```
+
+#### Install the package for development mode
+
 ```bash
 # Using quotes for zsh compatibility
 $ pip install -e '.[dev]'

--- a/mkdocsmerge/__init__.py
+++ b/mkdocsmerge/__init__.py
@@ -2,4 +2,4 @@
 """Init module of MkDocs Merge"""
 
 
-__version__ = '0.9.0'
+__version__ = "0.10.0"

--- a/mkdocsmerge/tests/copy_tree_test.py
+++ b/mkdocsmerge/tests/copy_tree_test.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+import os
+import shutil
+import tempfile
+import unittest
+
+from mkdocsmerge.merge import merge_sites
+
+
+class TestCopyTreeWhenModuleImportMerge(unittest.TestCase):
+    """
+    This test is needed because there was a bug where subsequent calls to distutil.copy_tree
+    would fail when mkdocs-merge was used as a module (https://stackoverflow.com/a/28055993/920464)
+    Even though the code was updated to use shutil.copytree, this test remains valuable to prevent
+    a similar bug from happening again.
+    """
+
+    def setUp(self):
+        # Create an isolated temp directory and cd into it
+        self.tmpdir = tempfile.mkdtemp()
+        self.old_cwd = os.getcwd()
+        os.chdir(self.tmpdir)
+
+        # --- Set up a fake siteA with mkdocs.yml + docs/index.md ---
+        os.makedirs("siteA/docs", exist_ok=True)
+        with open("siteA/mkdocs.yml", "w") as f:
+            f.write("site_name: siteA\n" "nav:\n" "  - Home: index.md\n")
+        with open("siteA/docs/index.md", "w") as f:
+            f.write("# Hello from siteA\n")
+
+        # --- Prepare the master/docs folder ---
+        os.makedirs("master/docs", exist_ok=True)
+
+    def tearDown(self):
+        # Cleanup
+        os.chdir(self.old_cwd)
+        shutil.rmtree(self.tmpdir)
+
+    def test_merge_twice_with_deletion(self):
+        master_docs = os.path.join("master", "docs")
+        # First merge should always succeed
+        merge_sites(["siteA"], master_docs, unify_sites=False, print_func=print)
+        first_copy = os.path.join(master_docs, "sitea", "index.md")
+        self.assertTrue(
+            os.path.isfile(first_copy),
+            f"After first merge, expected {first_copy} to exist",
+        )
+
+        # Remove the merged folder to trigger the old distutils cache bug
+        shutil.rmtree(os.path.join(master_docs, "sitea"))
+
+        # Second merge should *not* raise and should recreate the files
+        # This failed with dir_util but succeeded with shutil
+        merge_sites(["siteA"], master_docs, unify_sites=False, print_func=print)
+        second_copy = os.path.join(master_docs, "sitea", "index.md")
+        self.assertTrue(
+            os.path.isfile(second_copy),
+            f"After second merge, expected {second_copy} to exist",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mkdocs-merge"
-version = "0.9.0"
+version = "0.10.0"
 description = "Tool to merge multiple MkDocs sites into a single directory"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
# Fixes

- Permanent fix for #20 (removed dependency on `distutils`): replaced `dir_util.copy_tree` with `shutil.copytree` to use a built-in and maintained API in the directory merge functionality, this avoids the bug of dir_util where it caches the created directories and fails when trying to create them a second time.

# Improvements

- Added a test to verify the scenario of deleting paths and merging them again when using mkdocs-merge as a module.
- Formatted code with Black formatter.
- Updated dev setup with instructions for setting up a virtual environment.