### PR TITLE
Fixing docs publishing via GitHub Actions

### DIFF
--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -17,6 +17,9 @@ permissions:
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
+    concurrency:
+      group: "pages"
+      cancel-in-progress: true
     steps:
       # 1) Check out the repo
       - name: Checkout repository

--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -15,11 +15,8 @@ permissions:
   id-token: write          # for authentication with deploy-pages
 
 jobs:
-  build-and-publish:
+  build:
     runs-on: ubuntu-latest
-    concurrency:
-      group: "pages"
-      cancel-in-progress: true
     steps:
       # 1) Check out the repo
       - name: Checkout repository
@@ -47,5 +44,14 @@ jobs:
         with:
           path: site/
 
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
       - name: Deploy to GitHub Pages
-        uses: actions/deploy-pages@v1
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
- Separating the publishing in 2 stages: build and deploy
- Adding explicit configuration for the deploy environment 

Additionally, I had to configure the GitHub Pages deployment source to "GitHub Actions" instead of branches.