### PR TITLE
Fix multiple merge duplication bug and add v0.11.0 release

### DIFF
--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -3,10 +3,6 @@ name: Publish MkDocs-Merge Documentation
 
 on:
   workflow_dispatch:
-  push:
-    paths:
-        - 'docs/**'
-        - 'mkdocs.yml'
 
 # Grant permissions needed by the Pages actions
 permissions:
@@ -17,6 +13,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
     steps:
       # 1) Check out the repo
       - name: Checkout repository

--- a/README.md
+++ b/README.md
@@ -3,9 +3,27 @@
 This simple tool allows you to merge the source of multiple [MkDocs](http://www.mkdocs.org/) sites
 into a single one converting each of the specified sites to a sub-site of the master site.
 
-Supports unification of sites with the same `site_name` into a single sub-site.
+**Key Features:**
+
+- Merge multiple MkDocs sites into a single master site
+- Automatic deduplication: multiple merges replace existing entries (no duplicates)
+- Site unification: combine sites with the same name into single navigation sections
+- File system updates: content is properly replaced when re-merging sites
+
+## Important Behavior Note (v0.11.0+)
+
+When running merge operations multiple times with the same sites, **existing site entries are replaced, not duplicated**. This allows you to update subsites by simply re-running the merge command with updated source content.
+
+For example:
+
+- First merge: Adds "Project A" to master site
+- Second merge with "Project A": Replaces the existing "Project A" entry completely with new content
+- Other sites not being merged remain unchanged
+
+This behavior change was introduced in v0.11.0 to fix a bug where multiple merges would create duplicate navigation entries.
 
 ## Changelog
+
 Access the changelog here: https://ovasquez.github.io/mkdocs-merge/changelog/
 
 > Note: Since version 0.6 MkDocs Merge added support for MkDocs 1.0 and dropped
@@ -13,6 +31,7 @@ Access the changelog here: https://ovasquez.github.io/mkdocs-merge/changelog/
 > See here for more details about the changes in [MkDocs 1.0](https://www.mkdocs.org/about/release-notes/#version-10-2018-08-03).
 
 ---
+
 [![PyPI version](https://img.shields.io/pypi/v/mkdocs-merge.svg)](https://pypi.python.org/pypi/mkdocs-merge)
 [![MkDocs Merge Validation Build](https://github.com/ovasquez/mkdocs-merge/actions/workflows/build.yml/badge.svg)](https://github.com/ovasquez/mkdocs-merge/actions/workflows/build.yml)
 
@@ -33,10 +52,56 @@ $ mkdocs-merge run MASTER_SITE SITES [-u]...
 ### Parameters
 
 - `MASTER_SITE`: the path to the MkDocs site where the base `mkdocs.yml` file resides. This is where all other sites
-    will be merged into.
+  will be merged into.
 - `SITES`: the paths to each of the MkDocs sites that will be merged. Each of these paths is expected to have a
-    `mkdocs.yml` file and a `docs` folder.
-- `-u` (optional): Unify sites with the same "site_name" into a single sub-site.  
+  `mkdocs.yml` file and a `docs` folder.
+- `-u` (optional): Unify sites with the same "site_name" into a single sub-site. See [Unification Feature](#unification-feature) below for details.
+
+> **Note:** If you merge the same site multiple times, the existing entry will be replaced with the new content (not duplicated). This allows you to update subsites by re-running the merge command.
+
+## Unification Feature
+
+The `-u` flag enables **site unification**, which combines multiple sites that have the same `site_name` into a single navigation section. This is useful when you have related documentation split across multiple directories but want them to appear as one logical section.
+
+### Without Unification (default behavior)
+
+```bash
+$ mkdocs-merge run master-site api-core api-plugins
+```
+
+If both `api-core` and `api-plugins` have `site_name: "API Documentation"` in their `mkdocs.yml`, you'll get:
+
+```yaml
+nav:
+  - Home: index.md
+  - API Documentation: # From api-core
+      - Core Functions: api_documentation/core.md
+  - API Documentation: # From api-plugins (duplicate entry)
+      - Plugin System: api_documentation/plugins.md
+```
+
+### With Unification
+
+```bash
+$ mkdocs-merge run master-site api-core api-plugins -u
+```
+
+The same sites will be unified into a single section:
+
+```yaml
+nav:
+  - Home: index.md
+  - API Documentation: # Combined into one section
+      - Core Functions: api_documentation/core.md # From api-core
+      - Plugin System: api_documentation/plugins.md # From api-plugins
+```
+
+### Use Cases
+
+- **Microservices documentation**: Each service has its own docs but you want them grouped under "Services"
+- **Multi-repository projects**: Different repos contribute to the same logical documentation section
+- **Team-based documentation**: Multiple teams contribute to the same section (e.g., "API Reference")
+- **Modular documentation**: Large documentation split across multiple directories for maintainability
 
 ### Example
 
@@ -50,7 +115,7 @@ A single MkDocs site will be created in `root/mypath/mysite`, and the sites in
 **Original `root/mypath/mysite/mkdocs.yml`**
 
 ```yaml
-...
+---
 nav:
   - Home: index.md
   - About: about.md
@@ -59,7 +124,7 @@ nav:
 **Merged `root/mypath/mysite/mkdocs.yml`**
 
 ```yaml
-...
+---
 nav:
   - Home: index.md
   - About: about.md

--- a/README.md
+++ b/README.md
@@ -12,15 +12,7 @@ into a single one converting each of the specified sites to a sub-site of the ma
 
 ## Important Behavior Note (v0.11.0+)
 
-When running merge operations multiple times with the same sites, **existing site entries are replaced, not duplicated**. This allows you to update subsites by simply re-running the merge command with updated source content.
-
-For example:
-
-- First merge: Adds "Project A" to master site
-- Second merge with "Project A": Replaces the existing "Project A" entry completely with new content
-- Other sites not being merged remain unchanged
-
-This behavior change was introduced in v0.11.0 to fix a bug where multiple merges would create duplicate navigation entries.
+When merging the same site multiple times, existing entries are **replaced** (not duplicated). This allows you to update subsites by re-running the merge command.
 
 ## Changelog
 
@@ -51,57 +43,24 @@ $ mkdocs-merge run MASTER_SITE SITES [-u]...
 
 ### Parameters
 
-- `MASTER_SITE`: the path to the MkDocs site where the base `mkdocs.yml` file resides. This is where all other sites
-  will be merged into.
-- `SITES`: the paths to each of the MkDocs sites that will be merged. Each of these paths is expected to have a
-  `mkdocs.yml` file and a `docs` folder.
-- `-u` (optional): Unify sites with the same "site_name" into a single sub-site. See [Unification Feature](#unification-feature) below for details.
+- `MASTER_SITE`: Path to the main MkDocs site (contains `mkdocs.yml`)
+- `SITES`: Paths to MkDocs sites to merge (each needs `mkdocs.yml` and `docs/` folder)
+- `-u` (optional): Unify sites with the same name into one section
 
-> **Note:** If you merge the same site multiple times, the existing entry will be replaced with the new content (not duplicated). This allows you to update subsites by re-running the merge command.
+> **Note:** Re-merging the same site replaces the existing content (enables updates).
 
 ## Unification Feature
 
-The `-u` flag enables **site unification**, which combines multiple sites that have the same `site_name` into a single navigation section. This is useful when you have related documentation split across multiple directories but want them to appear as one logical section.
+The `-u` flag combines multiple sites with the same `site_name` into a single navigation section.
 
-### Without Unification (default behavior)
+**Without `-u`:** Sites with the same name create duplicate navigation entries.  
+**With `-u`:** Sites with the same name are merged into one section.
 
-```bash
-$ mkdocs-merge run master-site api-core api-plugins
-```
+**Use Cases:**
 
-If both `api-core` and `api-plugins` have `site_name: "API Documentation"` in their `mkdocs.yml`, you'll get:
-
-```yaml
-nav:
-  - Home: index.md
-  - API Documentation: # From api-core
-      - Core Functions: api_documentation/core.md
-  - API Documentation: # From api-plugins (duplicate entry)
-      - Plugin System: api_documentation/plugins.md
-```
-
-### With Unification
-
-```bash
-$ mkdocs-merge run master-site api-core api-plugins -u
-```
-
-The same sites will be unified into a single section:
-
-```yaml
-nav:
-  - Home: index.md
-  - API Documentation: # Combined into one section
-      - Core Functions: api_documentation/core.md # From api-core
-      - Plugin System: api_documentation/plugins.md # From api-plugins
-```
-
-### Use Cases
-
-- **Microservices documentation**: Each service has its own docs but you want them grouped under "Services"
-- **Multi-repository projects**: Different repos contribute to the same logical documentation section
-- **Team-based documentation**: Multiple teams contribute to the same section (e.g., "API Reference")
-- **Modular documentation**: Large documentation split across multiple directories for maintainability
+- Microservices documentation grouped under "Services"
+- Multi-repository projects in the same logical section
+- Team-based documentation contributions
 
 ### Example
 
@@ -166,7 +125,7 @@ $ tox
 
 ### Publishing
 
-The publishing process was updated to use GitHub Actions.
+Package publishing uses GitHub Actions. Documentation is published manually from main branch via Actions tab.
 
 ## Project Status
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,9 +3,9 @@
 ## 0.11.0 - July 4, 2025
 
 - **Breaking change:** Fixed multiple merge duplication bug where running merge operations multiple times would create duplicate site entries in the master navigation.
-- **Behavior change:** When the same site is merged multiple times, existing entries are now REPLACED (not duplicated) to allow for site updates. This means if "Project A" already exists in the master site and you merge "Project A" again, the old entry will be completely removed and replaced with the new content.
+- **Behavior change:** When the same site is merged multiple times, existing entries are now replaced (not duplicated) to allow for site updates.
+- **Documentation pipeline:** Changed documentation publishing to manual trigger only.
 - Added comprehensive test suite for multiple merge scenarios including mixed existing/new sites and interaction with the unify_sites feature.
-- Added detailed documentation explaining the replace behavior to prevent user confusion.
 - Formatting all code with black formatter.
 
 ## 0.10.0 - May 17, 2025

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,37 +1,54 @@
 # Changelog
 
+## 0.11.0 - July 4, 2025
+
+- **Breaking change:** Fixed multiple merge duplication bug where running merge operations multiple times would create duplicate site entries in the master navigation.
+- **Behavior change:** When the same site is merged multiple times, existing entries are now REPLACED (not duplicated) to allow for site updates. This means if "Project A" already exists in the master site and you merge "Project A" again, the old entry will be completely removed and replaced with the new content.
+- Added comprehensive test suite for multiple merge scenarios including mixed existing/new sites and interaction with the unify_sites feature.
+- Added detailed documentation explaining the replace behavior to prevent user confusion.
+- Formatting all code with black formatter.
+
 ## 0.10.0 - May 17, 2025
+
 - Permanent fix for [#20](https://github.com/ovasquez/mkdocs-merge/issues/20): replaced `dir_util.copy_tree` with `shutil.copytree` to use a built-in and maintained API in the directory merge functionality.
 - Added a test to verify the scenario of deleting paths and merging them again when using mkdocs-merge as a module.
 
 ## 0.9.0 - July 30, 2024
+
 - Fixed bug of `dir_util.copy_tree` caused by setuptools moving to 70.2.0 (fixes [#20](https://github.com/ovasquez/mkdocs-merge/issues/20)).
 - Updated dependency on deprecated distutils package to use setuptools version.
 - Updated project to use `pyproject.toml` instead of `setup.py` (package version now has to be manually kept in sync).
 
 ## 0.8.0 - January 20, 2023
+
 - Added support for section index pages
   [feature from MkDocs Material](https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#section-index-pages)
   (thanks to [@Acerinth](https://github.com/Acerinth)).
 
 ## 0.7.0 - November 16, 2022
+
 - **Breaking change:** removed support for Python 2 and Python 3.4.
 - Updated several dependencies.
 - DEV: migrated tests from nose to pytest.
 
 ## 0.6.0 - August 29, 2018
+
 - **Breaking change:** added support for added support for MkDocs 1.0 and dropped support for earlier versions.
 
 ## 0.5.0 - June 1, 2018
+
 - Fixed the merge process ignoring the `docs` folder in the `mkdocs.yml` of the
   sites to merge.
 - Removed support for Python 3.3 due to pip removing support for it.
 
 ## 0.4.2 - February 14, 2018
+
 - Fixed import error in `merge.py` when used in Windows.
 
 ## 0.4.1 - February 14, 2018
+
 - Fixed import error when used from CLI.
 
 ## 0.4.0 - February 2, 2018
+
 - Separate CLI functionality from the Merge logic for a more module friendly package.

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,17 +3,31 @@
 This simple tool allows you to merge the source of multiple [MkDocs](http://www.mkdocs.org/) sites
 into a single one converting each of the specified sites to a sub-site of the master site.
 
-Supports unification of sites with the same `site_name` into a single sub-site.
+**Key Features:**
+
+- Merge multiple MkDocs sites into a single master site
+- Automatic deduplication: multiple merges replace existing entries (no duplicates)
+- Site unification: combine sites with the same name into single navigation sections
+- File system updates: content is properly replaced when re-merging sites
+
+## Important Behavior Note (v0.11.0+)
+
+When merging the same site multiple times, existing entries are **replaced** (not duplicated). This allows you to update subsites by re-running the merge command.
+
+## Changelog
+
+Access the changelog here: https://ovasquez.github.io/mkdocs-merge/changelog/
 
 > Note: Since version 0.6 MkDocs Merge added support for MkDocs 1.0 and dropped
 > support for earlier versions.
 > See here for more details about the changes in [MkDocs 1.0](https://www.mkdocs.org/about/release-notes/#version-10-2018-08-03).
 
 ---
+
 [![PyPI version](https://img.shields.io/pypi/v/mkdocs-merge.svg)](https://pypi.python.org/pypi/mkdocs-merge)
 [![MkDocs Merge Validation Build](https://github.com/ovasquez/mkdocs-merge/actions/workflows/build.yml/badge.svg)](https://github.com/ovasquez/mkdocs-merge/actions/workflows/build.yml)
 
-MkDocs-Merge supports Python versions 3.5+ and pypy.
+MkDocs-Merge officially supports Python versions 3.8, 3.9 and 3.10. It has been tested to work correctly in previous 3.X versions, but those are no longer officially supported.
 
 ## Install
 
@@ -29,11 +43,24 @@ $ mkdocs-merge run MASTER_SITE SITES [-u]...
 
 ### Parameters
 
-- `MASTER_SITE`: the path to the MkDocs site where the base `mkdocs.yml` file resides. This is where all other sites
-    will be merged into.
-- `SITES`: the paths to each of the MkDocs sites that will be merged. Each of these paths is expected to have a
-    `mkdocs.yml` file and a `docs` folder.
-- `-u` (optional): Unify sites with the same "site_name" into a single sub-site.  
+- `MASTER_SITE`: Path to the main MkDocs site (contains `mkdocs.yml`)
+- `SITES`: Paths to MkDocs sites to merge (each needs `mkdocs.yml` and `docs/` folder)
+- `-u` (optional): Unify sites with the same name into one section
+
+> **Note:** Re-merging the same site replaces the existing content (enables updates).
+
+## Unification Feature
+
+The `-u` flag combines multiple sites with the same `site_name` into a single navigation section.
+
+**Without `-u`:** Sites with the same name create duplicate navigation entries.  
+**With `-u`:** Sites with the same name are merged into one section.
+
+**Use Cases:**
+
+- Microservices documentation grouped under "Services"
+- Multi-repository projects in the same logical section
+- Team-based documentation contributions
 
 ### Example
 
@@ -47,7 +74,7 @@ A single MkDocs site will be created in `root/mypath/mysite`, and the sites in
 **Original `root/mypath/mysite/mkdocs.yml`**
 
 ```yaml
-...
+---
 nav:
   - Home: index.md
   - About: about.md
@@ -56,7 +83,7 @@ nav:
 **Merged `root/mypath/mysite/mkdocs.yml`**
 
 ```yaml
-...
+---
 nav:
   - Home: index.md
   - About: about.md
@@ -98,7 +125,7 @@ $ tox
 
 ### Publishing
 
-The publishing process was updated to use GitHub Actions.
+Package publishing uses GitHub Actions. Documentation is published manually from main branch via Actions tab.
 
 ## Project Status
 

--- a/mkdocsmerge/__init__.py
+++ b/mkdocsmerge/__init__.py
@@ -2,4 +2,4 @@
 """Init module of MkDocs Merge"""
 
 
-__version__ = "0.10.0"
+__version__ = "0.11.0"

--- a/mkdocsmerge/__main__.py
+++ b/mkdocsmerge/__main__.py
@@ -4,12 +4,17 @@ import click
 from mkdocsmerge import __version__
 from mkdocsmerge import merge
 
-UNIFY_HELP = ('Unify sites with the same "site_name" into a single sub-site. Contents of unified '
-              'sub-sites will be stored in the same subsite folder.')
+UNIFY_HELP = (
+    'Unify sites with the same "site_name" into a single navigation '
+    "section. When multiple sites have identical site_name values, their "
+    "navigation entries will be combined under one section instead of "
+    "creating duplicate entries. Useful for grouping related documentation "
+    "from multiple sources."
+)
 
 
-@click.group(context_settings={'help_option_names': ['-h', '--help']})
-@click.version_option(__version__, '-V', '--version')
+@click.group(context_settings={"help_option_names": ["-h", "--help"]})
+@click.version_option(__version__, "-V", "--version")
 def cli():
     """
     MkDocs-Merge
@@ -31,9 +36,9 @@ def cli():
 
 
 @cli.command()
-@click.argument('master-site', type=click.Path())
-@click.argument('sites', type=click.Path(), nargs=-1)
-@click.option('-u', '--unify-sites', is_flag=True, help=UNIFY_HELP)
+@click.argument("master-site", type=click.Path())
+@click.argument("sites", type=click.Path(), nargs=-1)
+@click.option("-u", "--unify-sites", is_flag=True, help=UNIFY_HELP)
 def run(master_site, sites, unify_sites):
     """
     Executes the site merging.\n

--- a/mkdocsmerge/merge.py
+++ b/mkdocsmerge/merge.py
@@ -8,6 +8,26 @@ CONFIG_NAVIGATION = "nav"
 
 
 def run_merge(master_site, sites, unify_sites, print_func):
+    """
+    Merges multiple MkDocs sites into a master site.
+
+    When the same site is merged multiple times, existing entries are REPLACED
+    (not duplicated) to allow for site updates. This means:
+    - If "Project A" already exists in the master site and you merge "Project A" again,
+      the old "Project A" entry will be completely removed and replaced with the new one.
+    - Only the current content from the source site will be included.
+    - Other sites not being merged will remain unchanged.
+
+    Args:
+        master_site: Path to the master site directory
+        sites: List of site directory paths to merge
+        unify_sites: If True, sites with the same name within a single merge
+                    operation will be unified
+        print_func: Function to use for printing status messages
+
+    Returns:
+        Dictionary containing the updated master site data
+    """
 
     # Custom argument validation instead of an ugly generic error
     if not sites:
@@ -20,10 +40,7 @@ def run_merge(master_site, sites, unify_sites, print_func):
     # Read the mkdocs.yml from the master site
     master_yaml = os.path.join(master_site, MKDOCS_YML)
     if not os.path.isfile(master_yaml):
-        print_func(
-            "Could not find the master site yml file, "
-            "make sure it exists: " + master_yaml
-        )
+        print_func("Could not find the master site yml file, " "make sure it exists: " + master_yaml)
         return None
 
     # Round-trip yaml loader to preserve formatting and comments
@@ -33,6 +50,20 @@ def run_merge(master_site, sites, unify_sites, print_func):
 
     master_docs_dir = master_data.get("docs_dir", "docs")
     master_docs_root = os.path.join(master_site, master_docs_dir)
+
+    # Get site names that will be merged for deduplication
+    site_names_to_merge = get_site_names_from_sites(sites, print_func)
+
+    # Remove existing entries for sites that are being re-merged to prevent
+    # duplication
+    if site_names_to_merge:
+        original_nav_count = len(master_data[CONFIG_NAVIGATION])
+        master_data[CONFIG_NAVIGATION] = remove_existing_sites_from_nav(
+            master_data[CONFIG_NAVIGATION], site_names_to_merge
+        )
+        removed_count = original_nav_count - len(master_data[CONFIG_NAVIGATION])
+        if removed_count > 0:
+            print_func(f"Removed {removed_count} existing site entries to prevent duplication")
 
     # Get all site's navigation pages and copy their files
     new_navs = merge_sites(sites, master_docs_root, unify_sites, print_func)
@@ -58,10 +89,7 @@ def merge_sites(sites, master_docs_root, unify_sites, print_func):
         print_func("\nAttempting to merge site: " + site)
         site_yaml = os.path.join(site, MKDOCS_YML)
         if not os.path.isfile(site_yaml):
-            print_func(
-                "Could not find the site yaml file, this site will be "
-                'skipped: "' + site_yaml + '"'
-            )
+            print_func("Could not find the site yaml file, this site will be " 'skipped: "' + site_yaml + '"')
             continue
 
         with open(site_yaml) as site_file:
@@ -69,24 +97,17 @@ def merge_sites(sites, master_docs_root, unify_sites, print_func):
                 yaml = YAML(typ="safe")
                 site_data = yaml.load(site_file)
             except Exception:
-                print_func(
-                    'Error loading the yaml file "' + site_yaml + '". '
-                    "This site will be skipped."
-                )
+                print_func('Error loading the yaml file "' + site_yaml + '". ' "This site will be skipped.")
                 continue
 
         # Check 'site_data' has the 'nav' mapping
         if CONFIG_NAVIGATION not in site_data:
             print_func(
-                'Could not find the "nav" entry in the yaml file: "'
-                + site_yaml
-                + '", this site will be skipped.'
+                'Could not find the "nav" entry in the yaml file: "' + site_yaml + '", this site will be skipped.'
             )
             if "pages" in site_data:
                 raise ValueError(
-                    "The site "
-                    + site_yaml
-                    + ' has the "pages" setting in the YAML file which is not '
+                    "The site " + site_yaml + ' has the "pages" setting in the YAML file which is not '
                     "supported since MkDocs 1.0 and is not supported anymore by MkDocs Merge. Please "
                     "update your site to MkDocs 1.0 or higher."
                 )
@@ -108,38 +129,23 @@ def merge_sites(sites, master_docs_root, unify_sites, print_func):
         new_site_docs = os.path.join(master_docs_root, site_root)
 
         if not os.path.isdir(old_site_docs):
-            print_func(
-                'Could not find the site "docs_dir" folder. This site will '
-                "be skipped: " + old_site_docs
-            )
+            print_func('Could not find the site "docs_dir" folder. This site will ' "be skipped: " + old_site_docs)
             continue
 
         try:
             # Update if the directory already exists to allow site unification
             shutil.copytree(old_site_docs, new_site_docs, dirs_exist_ok=True)
         except OSError as exc:
-            print_func(
-                'Error copying files of site "'
-                + site_name
-                + '". This site will be skipped.'
-            )
+            print_func('Error copying files of site "' + site_name + '". This site will be skipped.')
             print_func(exc.strerror)
             continue
 
         # Update the nav data with the new path after files have been copied
         update_navs(site_data[CONFIG_NAVIGATION], site_root, print_func=print_func)
-        merge_single_site(
-            new_navs, site_name, site_data[CONFIG_NAVIGATION], unify_sites
-        )
+        merge_single_site(new_navs, site_name, site_data[CONFIG_NAVIGATION], unify_sites)
 
         # Inform the user
-        print_func(
-            'Successfully merged site located in "'
-            + site
-            + '" as sub-site "'
-            + site_name
-            + '"\n'
-        )
+        print_func('Successfully merged site located in "' + site + '" as sub-site "' + site_name + '"\n')
 
     return new_navs
 
@@ -158,7 +164,8 @@ def merge_single_site(global_nav, site_name, site_nav, unify_sites):
                 page[site_name] = page[site_name] + site_nav
                 unified = True
                 break
-    # Append to the global list if no unification was requested or it didn't exist.
+    # Append to the global list if no unification was requested or it didn't
+    # exist.
     if (not unify_sites) or (not unified):
         global_nav.append({site_name: site_nav})
 
@@ -184,3 +191,76 @@ def update_navs(navs, site_root, print_func):
                 print_func('Error merging the "nav" entry in the site: ' + site_root)
     else:
         print_func('Error merging the "nav" entry in the site: ' + site_root)
+
+
+def remove_existing_sites_from_nav(master_nav, site_names_to_remove):
+    """
+    Removes existing site entries from the master navigation that match
+    the site names being merged. This prevents duplication when running
+    multiple merge operations.
+
+    Args:
+        master_nav: List of navigation entries (the master site's nav)
+        site_names_to_remove: Set of site names to remove from existing nav
+
+    Returns:
+        List with matching site entries removed
+    """
+    if not master_nav or not site_names_to_remove:
+        return master_nav
+
+    # Filter out navigation entries that match site names being merged
+    filtered_nav = []
+    for nav_entry in master_nav:
+        if isinstance(nav_entry, dict):
+            # Check if this nav entry contains any of the site names to remove
+            should_keep = True
+            for site_name in site_names_to_remove:
+                if site_name in nav_entry:
+                    should_keep = False
+                    break
+            if should_keep:
+                filtered_nav.append(nav_entry)
+        else:
+            # Keep non-dict entries (like simple strings)
+            filtered_nav.append(nav_entry)
+
+    return filtered_nav
+
+
+def get_site_names_from_sites(sites, print_func):
+    """
+    Extract site names from the list of site directories by reading their
+    mkdocs.yml files. This is needed for deduplication logic.
+
+    Args:
+        sites: List of site directory paths
+        print_func: Function to use for printing messages
+
+    Returns:
+        Set of site names that will be merged
+    """
+    site_names = set()
+
+    for site in sites:
+        site_yaml = os.path.join(site, MKDOCS_YML)
+        if not os.path.isfile(site_yaml):
+            continue
+
+        try:
+            yaml = YAML(typ="safe")
+            with open(site_yaml) as site_file:
+                site_data = yaml.load(site_file)
+
+            if site_data:
+                try:
+                    site_name = str(site_data["site_name"])
+                except Exception:
+                    site_name = os.path.basename(site)
+
+                site_names.add(site_name)
+        except Exception:
+            # Skip sites with invalid YAML - they'll be handled in merge_sites
+            continue
+
+    return site_names

--- a/mkdocsmerge/tests/merge_test.py
+++ b/mkdocsmerge/tests/merge_test.py
@@ -12,7 +12,7 @@ class TestSiteMerges(unittest.TestCase):
     """
 
     def setUp(self):
-        print('Test: ' + self._testMethodName)
+        print("Test: " + self._testMethodName)
 
     def test_update_pages(self):
         """
@@ -20,27 +20,31 @@ class TestSiteMerges(unittest.TestCase):
         new subroute at the begining of each page's path
         """
         # Create original and expected data structures
-        subpage = 'new_root'
-        subpage_path = subpage + '/'
-        nav = [{'Home': 'index.md'},
-               {'About': 'menu/about.md'},
-               {'Projects': [
-                   {'First': 'projects/first.md'},
-                   {'Nested': [
-                       {'Third': 'projects/nest/third.md'}
-                   ]},
-                   {'Second': 'projects/second.md'}
-               ]}]
+        subpage = "new_root"
+        subpage_path = subpage + "/"
+        nav = [
+            {"Home": "index.md"},
+            {"About": "menu/about.md"},
+            {
+                "Projects": [
+                    {"First": "projects/first.md"},
+                    {"Nested": [{"Third": "projects/nest/third.md"}]},
+                    {"Second": "projects/second.md"},
+                ]
+            },
+        ]
 
-        expected = [{'Home': subpage_path + 'index.md'},
-                    {'About': subpage_path + 'menu/about.md'},
-                    {'Projects': [
-                        {'First': subpage_path + 'projects/first.md'},
-                        {'Nested': [
-                            {'Third': subpage_path + 'projects/nest/third.md'}
-                        ]},
-                        {'Second': subpage_path + 'projects/second.md'}
-                    ]}]
+        expected = [
+            {"Home": subpage_path + "index.md"},
+            {"About": subpage_path + "menu/about.md"},
+            {
+                "Projects": [
+                    {"First": subpage_path + "projects/first.md"},
+                    {"Nested": [{"Third": subpage_path + "projects/nest/third.md"}]},
+                    {"Second": subpage_path + "projects/second.md"},
+                ]
+            },
+        ]
 
         mkdocsmerge.merge.update_navs(nav, subpage, lambda x: None)
         self.assertEqual(nav, expected)
@@ -49,35 +53,50 @@ class TestSiteMerges(unittest.TestCase):
         """
         Verifies merging of a single site's nav to the global nav's data without unification.
         """
-        site_name = 'Projects'
+        site_name = "Projects"
         # Create original and expected data structures
-        global_nav = [{'Home': 'index.md'},
-                      {'About': 'menu/about.md'},
-                      {site_name: [
-                          {'First': 'projects/first.md'},
-                          {'Second': 'projects/second.md'}
-                      ]}]
+        global_nav = [
+            {"Home": "index.md"},
+            {"About": "menu/about.md"},
+            {
+                site_name: [
+                    {"First": "projects/first.md"},
+                    {"Second": "projects/second.md"},
+                ]
+            },
+        ]
 
-        site_nav = [{'Nested': [
-            {'Third': 'projects/nest/third.md'},
-            {'Fourth': 'projects/nest/fourth.md'}
-        ]}]
+        site_nav = [
+            {
+                "Nested": [
+                    {"Third": "projects/nest/third.md"},
+                    {"Fourth": "projects/nest/fourth.md"},
+                ]
+            }
+        ]
 
-        expected = [{'Home': 'index.md'},
-                    {'About': 'menu/about.md'},
-                    {site_name: [
-                        {'First': 'projects/first.md'},
-                        {'Second': 'projects/second.md'},
-                    ]},
-                    {site_name: [
-                        {'Nested': [
-                            {'Third': 'projects/nest/third.md'},
-                            {'Fourth': 'projects/nest/fourth.md'}
-                        ]},
-                    ]}]
+        expected = [
+            {"Home": "index.md"},
+            {"About": "menu/about.md"},
+            {
+                site_name: [
+                    {"First": "projects/first.md"},
+                    {"Second": "projects/second.md"},
+                ]
+            },
+            {
+                site_name: [
+                    {
+                        "Nested": [
+                            {"Third": "projects/nest/third.md"},
+                            {"Fourth": "projects/nest/fourth.md"},
+                        ]
+                    },
+                ]
+            },
+        ]
 
-        mkdocsmerge.merge.merge_single_site(
-            global_nav, site_name, site_nav, False)
+        mkdocsmerge.merge.merge_single_site(global_nav, site_name, site_nav, False)
         self.assertEqual(global_nav, expected)
 
     def test_singe_site_merge_unified(self):
@@ -85,33 +104,46 @@ class TestSiteMerges(unittest.TestCase):
         Verifies merging of a single site's nav to the global nav's data with unification
         of the sub-sites with the same site_name
         """
-        site_name = 'Projects'
+        site_name = "Projects"
         # Create original and expected data structures
-        global_nav = [{'Home': 'index.md'},
-                      {'About': 'menu/about.md'},
-                      {site_name: [
-                          {'First': 'projects/first.md'},
-                          {'Second': 'projects/second.md'}
-                      ]}]
+        global_nav = [
+            {"Home": "index.md"},
+            {"About": "menu/about.md"},
+            {
+                site_name: [
+                    {"First": "projects/first.md"},
+                    {"Second": "projects/second.md"},
+                ]
+            },
+        ]
 
-        site_nav = [{'Nested': [
-            {'Third': 'projects/nest/third.md'},
-            {'Fourth': 'projects/nest/fourth.md'}
-        ]}]
+        site_nav = [
+            {
+                "Nested": [
+                    {"Third": "projects/nest/third.md"},
+                    {"Fourth": "projects/nest/fourth.md"},
+                ]
+            }
+        ]
 
-        expected = [{'Home': 'index.md'},
-                    {'About': 'menu/about.md'},
-                    {site_name: [
-                        {'First': 'projects/first.md'},
-                        {'Second': 'projects/second.md'},
-                        {'Nested': [
-                            {'Third': 'projects/nest/third.md'},
-                            {'Fourth': 'projects/nest/fourth.md'}
-                        ]},
-                    ]}]
+        expected = [
+            {"Home": "index.md"},
+            {"About": "menu/about.md"},
+            {
+                site_name: [
+                    {"First": "projects/first.md"},
+                    {"Second": "projects/second.md"},
+                    {
+                        "Nested": [
+                            {"Third": "projects/nest/third.md"},
+                            {"Fourth": "projects/nest/fourth.md"},
+                        ]
+                    },
+                ]
+            },
+        ]
 
-        mkdocsmerge.merge.merge_single_site(
-            global_nav, site_name, site_nav, True)
+        mkdocsmerge.merge.merge_single_site(global_nav, site_name, site_nav, True)
         self.assertEqual(global_nav, expected)
 
     def test_update_pages_with_section_indexes(self):
@@ -119,25 +151,37 @@ class TestSiteMerges(unittest.TestCase):
         Verifies the correct updating of the section index pages' paths.
         """
         # Create original and expected data structures
-        subpage = 'new_root'
-        subpage_path = subpage + '/'
-        nav = [{'Home': 'index.md'},
-               {'Projects': [
-                   'projects/index.md',
-                   {'Nested': [
-                       'projects/nested/index.md',
-                       {'Third': 'projects/nest/third.md'}
-                   ]}
-               ]}]
+        subpage = "new_root"
+        subpage_path = subpage + "/"
+        nav = [
+            {"Home": "index.md"},
+            {
+                "Projects": [
+                    "projects/index.md",
+                    {
+                        "Nested": [
+                            "projects/nested/index.md",
+                            {"Third": "projects/nest/third.md"},
+                        ]
+                    },
+                ]
+            },
+        ]
 
-        expected = [{'Home': subpage_path + 'index.md'},
-                    {'Projects': [
-                        subpage_path + 'projects/index.md',
-                        {'Nested': [
-                            subpage_path + 'projects/nested/index.md',
-                            {'Third': subpage_path + 'projects/nest/third.md'}
-                        ]}
-                    ]}]
+        expected = [
+            {"Home": subpage_path + "index.md"},
+            {
+                "Projects": [
+                    subpage_path + "projects/index.md",
+                    {
+                        "Nested": [
+                            subpage_path + "projects/nested/index.md",
+                            {"Third": subpage_path + "projects/nest/third.md"},
+                        ]
+                    },
+                ]
+            },
+        ]
 
         mkdocsmerge.merge.update_navs(nav, subpage, lambda x: None)
         self.assertEqual(nav, expected)

--- a/mkdocsmerge/tests/multiple_merge_test.py
+++ b/mkdocsmerge/tests/multiple_merge_test.py
@@ -1,0 +1,297 @@
+"""
+Tests for multiple merge operations to verify deduplication behavior.
+"""
+
+import os
+import shutil
+import tempfile
+import unittest
+
+import mkdocsmerge.merge
+
+from .utils import generate_website
+
+
+class TestMultipleMerge(unittest.TestCase):
+    """
+    Test class for verifying multiple merge operations don't create duplicates.
+    """
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.owd = os.getcwd()
+        os.chdir(self.tmpdir)
+        print("Test: " + self._testMethodName)
+
+    def tearDown(self):
+        # Avoid leaving the temp directory open until program exit (bug in
+        # Windows)
+        os.chdir(self.owd)
+        shutil.rmtree(self.tmpdir)
+
+    def test_multiple_merge_same_sites_without_unify(self):
+        """
+        Test that merging the same sites multiple times correctly REPLACES
+        existing entries instead of creating duplicates.
+        This test verifies the fix for the multiple merge bug.
+        """
+        # Create master site and subsites
+        master_yml = {
+            "site_name": "Master Website",
+            "nav": [{"Home": "index.md"}],
+            "docs_dir": "docs",
+        }
+
+        subsite_yml = {
+            "site_name": "Project A",
+            "nav": [{"Home": "index.md"}, {"About": "about.md"}],
+        }
+
+        generate_website(self.tmpdir, "master", master_yml)
+        generate_website(self.tmpdir, "project_a", subsite_yml)
+
+        # First merge
+        result1 = mkdocsmerge.merge.run_merge("master", ["project_a"], False, lambda x: None)
+
+        # Verify first merge worked correctly
+        expected_after_first = {
+            "site_name": "Master Website",
+            "docs_dir": "docs",
+            "nav": [
+                {"Home": "index.md"},
+                {
+                    "Project A": [
+                        {"Home": "project_a/index.md"},
+                        {"About": "project_a/about.md"},
+                    ]
+                },
+            ],
+        }
+        self.assertEqual(result1, expected_after_first)
+
+        # Second merge of the same site - this should demonstrate the bug
+        result2 = mkdocsmerge.merge.run_merge("master", ["project_a"], False, lambda x: None)
+
+        # Debug: Print actual result to see what's happening
+        print("Actual result2:", result2)
+
+        # CORRECT behavior after fix: should only have one entry per site
+        expected_correct_behavior = {
+            "site_name": "Master Website",
+            "docs_dir": "docs",
+            "nav": [
+                {"Home": "index.md"},
+                {
+                    "Project A": [  # Should only appear ONCE (replaced, not duplicated)
+                        {"Home": "project_a/index.md"},
+                        {"About": "project_a/about.md"},
+                    ]
+                },
+            ],
+        }
+
+        # This assertion now tests the CORRECT behavior
+        self.assertEqual(result2, expected_correct_behavior)
+
+    def test_multiple_merge_mixed_sites_without_unify(self):
+        """
+        Test merging with a mix of existing and new sites.
+        Verifies that existing sites are replaced and new sites are added correctly.
+        """
+        # Create master site and multiple subsites
+        master_yml = {
+            "site_name": "Master Website",
+            "nav": [{"Home": "index.md"}],
+        }
+
+        project_a_yml = {
+            "site_name": "Project A",
+            "nav": [{"Home": "index.md"}],
+        }
+
+        project_b_yml = {
+            "site_name": "Project B",
+            "nav": [{"Home": "index.md"}],
+        }
+
+        generate_website(self.tmpdir, "master", master_yml)
+        generate_website(self.tmpdir, "project_a", project_a_yml)
+        generate_website(self.tmpdir, "project_b", project_b_yml)
+
+        # First merge: add Project A
+        mkdocsmerge.merge.run_merge("master", ["project_a"], False, lambda x: None)
+
+        # Second merge: add Project A again + new Project B
+        result = mkdocsmerge.merge.run_merge("master", ["project_a", "project_b"], False, lambda x: None)
+
+        # Debug: print the actual result
+        print("Actual result:", result)
+
+        # CORRECT behavior after fix: Project A appears only once (replaced),
+        # Project B added
+        expected_correct = {
+            "site_name": "Master Website",
+            "nav": [
+                {"Home": "index.md"},
+                {"Project A": [{"Home": "project_a/index.md"}]},  # Replaced, not duplicated
+                {"Project B": [{"Home": "project_b/index.md"}]},  # New site (correct)
+            ],
+        }
+
+        # This assertion now tests the CORRECT behavior
+        self.assertEqual(result, expected_correct)
+
+    def test_multiple_merge_with_unify_sites(self):
+        """
+        Test multiple merges with unify_sites=True.
+        Verifies that the deduplication logic works correctly with the
+        existing unification feature.
+        """
+        # Create master site and subsites
+        master_yml = {
+            "site_name": "Master Website",
+            "nav": [{"Home": "index.md"}],
+        }
+
+        project_yml = {"site_name": "Projects", "nav": [{"First": "first.md"}]}
+
+        generate_website(self.tmpdir, "master", master_yml)
+        generate_website(self.tmpdir, "project1", project_yml)
+
+        # Create another subsite with same name but different content
+        project2_yml = {
+            "site_name": "Projects",  # Same name as project1
+            "nav": [{"Second": "second.md"}],
+        }
+        generate_website(self.tmpdir, "project2", project2_yml)
+
+        # First merge with unify_sites=True
+        result1 = mkdocsmerge.merge.run_merge("master", ["project1", "project2"], True, lambda x: None)
+
+        expected_after_first = {
+            "site_name": "Master Website",
+            "nav": [
+                {"Home": "index.md"},
+                {
+                    "Projects": [
+                        {"First": "projects/first.md"},
+                        {"Second": "projects/second.md"},
+                    ]
+                },
+            ],
+        }
+        self.assertEqual(result1, expected_after_first)  # Second merge of the same sites with unify_sites=True
+        result2 = mkdocsmerge.merge.run_merge("master", ["project1", "project2"], True, lambda x: None)
+
+        # CORRECT behavior after fix: should replace the existing entry, not
+        # duplicate
+        expected_correct = {
+            "site_name": "Master Website",
+            "nav": [
+                {"Home": "index.md"},
+                {
+                    "Projects": [  # Should only appear ONCE (replaced)
+                        {"First": "projects/first.md"},
+                        {"Second": "projects/second.md"},
+                    ]
+                },
+            ],
+        }
+
+        # This assertion now tests the CORRECT behavior
+        self.assertEqual(result2, expected_correct)
+
+    def test_file_system_consistency_multiple_merges(self):
+        """
+        Test that file system operations work correctly across multiple merges.
+        Verify that files are properly updated/replaced.
+        """
+        # Create master site
+        master_yml = {
+            "site_name": "Master Website",
+            "nav": [{"Home": "index.md"}],
+        }
+        generate_website(self.tmpdir, "master", master_yml)
+
+        # Create subsite with initial content
+        project_yml = {"site_name": "Project A", "nav": [{"Home": "index.md"}]}
+        generate_website(self.tmpdir, "project_a", project_yml)
+
+        # Write initial content to project file
+        initial_content = "# Initial Content\nThis is the initial version."
+        with open(os.path.join(self.tmpdir, "project_a", "docs", "index.md"), "w") as f:
+            f.write(initial_content)
+
+        # First merge
+        mkdocsmerge.merge.run_merge("master", ["project_a"], False, lambda x: None)
+
+        # Verify file was copied
+        copied_file = os.path.join(self.tmpdir, "master", "docs", "project_a", "index.md")
+        self.assertTrue(os.path.exists(copied_file))
+
+        with open(copied_file, "r") as f:
+            content = f.read()
+        self.assertEqual(content, initial_content)
+
+        # Update the source file content
+        updated_content = "# Updated Content\nThis is the updated version."
+        with open(os.path.join(self.tmpdir, "project_a", "docs", "index.md"), "w") as f:
+            f.write(updated_content)
+
+        # Second merge - should update the file
+        mkdocsmerge.merge.run_merge("master", ["project_a"], False, lambda x: None)
+
+        # Verify file content was updated
+        with open(copied_file, "r") as f:
+            content = f.read()
+        self.assertEqual(content, updated_content)
+
+    def test_multiple_merge_should_replace_not_duplicate(self):
+        """
+        Test that merging the same sites multiple times should REPLACE
+        existing entries, not create duplicates.
+
+        This test expects the CORRECT behavior and will FAIL until we fix the bug.
+        """
+        # Create master site and subsites
+        master_yml = {
+            "site_name": "Master Website",
+            "nav": [{"Home": "index.md"}],
+            "docs_dir": "docs",
+        }
+
+        subsite_yml = {
+            "site_name": "Project A",
+            "nav": [{"Home": "index.md"}, {"About": "about.md"}],
+        }
+
+        generate_website(self.tmpdir, "master", master_yml)
+        generate_website(self.tmpdir, "project_a", subsite_yml)
+
+        # First merge
+        mkdocsmerge.merge.run_merge("master", ["project_a"], False, lambda x: None)
+
+        # Second merge of the same site - should REPLACE, not duplicate
+        result2 = mkdocsmerge.merge.run_merge("master", ["project_a"], False, lambda x: None)
+
+        # CORRECT behavior: should only have one entry per site
+        expected_correct_behavior = {
+            "site_name": "Master Website",
+            "docs_dir": "docs",
+            "nav": [
+                {"Home": "index.md"},
+                {
+                    "Project A": [  # Should only appear ONCE
+                        {"Home": "project_a/index.md"},
+                        {"About": "project_a/about.md"},
+                    ]
+                },
+            ],
+        }
+
+        # This assertion will FAIL until we implement the fix
+        self.assertEqual(result2, expected_correct_behavior)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mkdocsmerge/tests/run_merge_test.py
+++ b/mkdocsmerge/tests/run_merge_test.py
@@ -17,48 +17,43 @@ class TestRunMerge(unittest.TestCase):
 
     def test_run_merge(self):
 
-        docs_dir_map = {
-            '__master__': 'master_docs',
-            'Test': 'test_docs'
-        }
+        docs_dir_map = {"__master__": "master_docs", "Test": "test_docs"}
 
-        site_names = ['__master__', 'Foo', 'Bar', 'Test']
+        site_names = ["__master__", "Foo", "Bar", "Test"]
         for site_name in site_names:
             docs_dir = docs_dir_map.get(site_name, None)
             yml = make_simple_yaml(site_name, docs_dir)
             generate_website(self.tmpdir, site_name, yml)
 
-        merged_pages = mkdocsmerge.merge.run_merge(
-            site_names[0], site_names[1:], True, lambda x: None)
+        merged_pages = mkdocsmerge.merge.run_merge(site_names[0], site_names[1:], True, lambda x: None)
 
         for site_name in site_names[1:]:
-            index_path = os.path.join(
-                site_name, docs_dir_map.get(site_name, 'docs'), 'index.md')
+            index_path = os.path.join(site_name, docs_dir_map.get(site_name, "docs"), "index.md")
             self.assertTrue(os.path.exists(index_path))
 
             docs_dir_path = os.path.join(
-                site_names[0], docs_dir_map.get(site_names[0], 'docs'),
-                '%s_website' % site_name.lower())
+                site_names[0],
+                docs_dir_map.get(site_names[0], "docs"),
+                "%s_website" % site_name.lower(),
+            )
             self.assertTrue(os.path.exists(docs_dir_path))
 
-        self.assertEqual(merged_pages, {
-            'site_name': '__master__ Website',
-            'nav': [
-                {'Home': "index.md"},
-                {'Foo Website': [
-                    {'Home': 'foo_website/index.md'}
-                ]},
-                {'Bar Website': [
-                    {'Home': 'bar_website/index.md'}
-                ]},
-                {'Test Website': [
-                    {'Home': 'test_website/index.md'}
-                ]}
-            ],
-            'docs_dir': 'master_docs'
-        })
+        self.assertEqual(
+            merged_pages,
+            {
+                "site_name": "__master__ Website",
+                "nav": [
+                    {"Home": "index.md"},
+                    {"Foo Website": [{"Home": "foo_website/index.md"}]},
+                    {"Bar Website": [{"Home": "bar_website/index.md"}]},
+                    {"Test Website": [{"Home": "test_website/index.md"}]},
+                ],
+                "docs_dir": "master_docs",
+            },
+        )
 
     def tearDown(self):
-        # Avoid leaving the temp directory open until program exit (bug in Windows)
+        # Avoid leaving the temp directory open until program exit (bug in
+        # Windows)
         os.chdir(self.owd)
         shutil.rmtree(self.tmpdir)

--- a/mkdocsmerge/tests/utils.py
+++ b/mkdocsmerge/tests/utils.py
@@ -10,26 +10,26 @@ def generate_website(directory, name, yml=None):
         yml = make_simple_yaml(name)
 
     yaml = YAML()
-    with open(os.path.join(root, 'mkdocs.yml'), 'w') as f:
+    with open(os.path.join(root, "mkdocs.yml"), "w") as f:
         yaml.dump(yml, f)
 
-    docs_folder = yml.get('docs_dir', 'docs')
+    docs_folder = yml.get("docs_dir", "docs")
 
     docs_dir = os.path.join(root, docs_folder)
     os.mkdir(docs_dir)
-    generate_dummy_pages(docs_dir, 'nav', yml['nav'])
+    generate_dummy_pages(docs_dir, "nav", yml["nav"])
 
 
 def make_simple_yaml(name, docs_dir=None):
     yml = {
-        'site_name': '%s Website' % name,
-        'nav': [
-            {'Home': "index.md"},
-        ]
+        "site_name": "%s Website" % name,
+        "nav": [
+            {"Home": "index.md"},
+        ],
     }
 
     if docs_dir:
-        yml['docs_dir'] = docs_dir
+        yml["docs_dir"] = docs_dir
     return yml
 
 
@@ -41,11 +41,14 @@ def generate_dummy_pages(docs_dir, key, node):
         for k, v in node.items():
             generate_dummy_pages(docs_dir, k, v)
     else:
-        path = os.path.join(docs_dir, str.replace(node, '\\', '/'))
+        path = os.path.join(docs_dir, str.replace(node, "\\", "/"))
         if not os.path.exists(os.path.dirname(path)):
             os.makedirs(os.path.dirname(path))
-        with open(path, 'w') as mdf:
-            mdf.write("""
+        with open(path, "w") as mdf:
+            mdf.write(
+                """
 * %s Title
 Contents
-""" % key)
+"""
+                % key
+            )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mkdocs-merge"
-version = "0.10.0"
+version = "0.11.0"
 description = "Tool to merge multiple MkDocs sites into a single directory"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
- Fixed bug where running merge operations multiple times created duplicate site entries
- Existing site entries are now REPLACED (not duplicated) when re-merging
- Added comprehensive test suite for multiple merge scenarios
- Enhanced documentation with behavior clarification and unification examples
- Formatted all code with black formatter
- Version bump to 0.11.0